### PR TITLE
do not add bundler - weird errors when a newer version is available

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,6 @@ gem "actionpack", ">= 2.3.5"
 
 gem "rake", :group => :development
 gem "yard", "~> 0.7", :group => :development
-gem "bundler", "~> 1.2.0", :group => :development
 gem "jeweler", "~> 1.8.4", :group => :development
 
 gem "rails", ">= 2.3.5", :group => :test


### PR DESCRIPTION
as soon as a newer bundler version is installed you have to `bundle _1.2.0_ exec ...` which is kind of annoying :)
