### PR TITLE
validate the callback function name

### DIFF
--- a/lib/charcoal/jsonp.rb
+++ b/lib/charcoal/jsonp.rb
@@ -2,6 +2,8 @@ require 'charcoal/controller_filter'
 
 module Charcoal
   module JSONP
+    VALID_JS_FN = /\A[_$a-z][$\w\.]*\z/i.freeze
+
     def self.included(klass)
       klass.extend(ClassMethods)
       klass.prepend_around_filter :add_jsonp_callback
@@ -31,7 +33,7 @@ module Charcoal
     end
 
     def jsonp_request?
-      params[:callback].present? && jsonp_allowed?
+      params[:callback] =~ VALID_JS_FN && jsonp_allowed?
     end
 
     def add_jsonp_callback

--- a/test/jsonp_test.rb
+++ b/test/jsonp_test.rb
@@ -87,6 +87,36 @@ class JSONPTest < ActionController::TestCase
         should "change content-type" do
           assert_equal "application/javascript", subject.response.content_type
         end
+
+        context "valid callback names" do
+          setup do
+            @valid_fns = ['foo', '_foo', '$foo', '$.foo', 'foo_v2', 'foo2', '__foo._foo']
+          end
+
+          should "add jsonp callback" do
+            @valid_fns.each do |fn|
+              subject.params.replace(:callback => fn, :action => "test")
+              subject.send(:add_jsonp_callback) {}
+
+              assert_equal "#{fn}(#{@response})", subject.response.body
+            end
+          end
+        end
+
+        context "invalid callback names" do
+          setup do
+            @invalid_fns = ['123', '123foo', 'SPAM!%0d%0afoo.com', "foo\nbar", '; foo()', '.foo']
+          end
+
+          should "not add jsonp callback" do
+            @invalid_fns.each do |fn|
+              subject.params.replace(:callback => fn, :action => "test")
+              subject.send(:add_jsonp_callback) {}
+
+              assert_equal @response, subject.response.body
+            end
+          end
+        end
       end
 
       context "without params" do


### PR DESCRIPTION
Simple regex to validate the name of a callback function. Unchecked, this is a potential place for injection.

Example: 
https://whitehatsecwapt1.zendesk.com/api/v2/locales/current.json?include=translations&packages=lotus&callback=ERROR!%0d%0aPlease%20visit%20www.whitehatsec.com%20for%20more%20information.%0d%0a%0d%0a%0d%0a%0d%0a%0d%0a%0d%0a%0d%0a%0d%0a%0d%0a%0d%0a%0d%0a%0d%0a%0d%0a%0d%0a%0d%0a%0d%0a%0d%0a%0d%0a%0d%0a%0d%0a%0d%0a%0d%0a%0d%0a%0d%0a%0d%0a%0d%0a%0d%0a%0d%0a%0d%0a%0d%0a%0d%0a%0d%0a%0d%0a%0d%0a%0d%0a%0d%0a%0d%0a%0d%0a%0d%0a%0d%0a%0d%0a%0d%0a%0d%0a%0d%0a%0d%0a%0d%0a%0d%0a%0d%0a%0d%0a%0d%0a%0d%0a%0d%0a%0d%0a%0d%0a%0d%0a%0d%0a%0d%0a%0d%0a%0d%0a%0d%0aHTTP/1.1

@steved 