### PR TITLE
Stop testing with Rails 4.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,6 @@ rvm:
   - 2.4.1
 gemfile:
   - gemfiles/rails3.2.gemfile
-  - gemfiles/rails4.1.gemfile
   - gemfiles/rails4.2.gemfile
   - gemfiles/rails5.0.gemfile
   - gemfiles/rails5.1.gemfile
@@ -25,5 +24,3 @@ matrix:
       gemfile: gemfiles/rails5.1.gemfile
     - rvm: 2.4.1
       gemfile: gemfiles/rails3.2.gemfile
-    - rvm: 2.4.1
-      gemfile: gemfiles/rails4.1.gemfile

--- a/gemfiles/rails3.2.gemfile
+++ b/gemfiles/rails3.2.gemfile
@@ -1,4 +1,4 @@
-eval_gemfile 'gemfiles/common.rb'
+eval_gemfile 'common.rb'
 
 gem 'rails', '~> 3.2.21'
 gem 'test-unit-minitest'

--- a/gemfiles/rails4.1.gemfile
+++ b/gemfiles/rails4.1.gemfile
@@ -1,4 +1,4 @@
-eval_gemfile 'gemfiles/common.rb'
+eval_gemfile 'common.rb'
 
 gem 'rails', '~> 4.1.14'
 gem 'actionpack-action_caching'

--- a/gemfiles/rails4.1.gemfile
+++ b/gemfiles/rails4.1.gemfile
@@ -1,4 +1,0 @@
-eval_gemfile 'common.rb'
-
-gem 'rails', '~> 4.1.14'
-gem 'actionpack-action_caching'

--- a/gemfiles/rails4.2.gemfile
+++ b/gemfiles/rails4.2.gemfile
@@ -1,4 +1,4 @@
-eval_gemfile 'gemfiles/common.rb'
+eval_gemfile 'common.rb'
 
 gem 'rails', '~> 4.2.5'
 gem 'actionpack-action_caching'

--- a/gemfiles/rails5.0.gemfile
+++ b/gemfiles/rails5.0.gemfile
@@ -1,4 +1,4 @@
-eval_gemfile 'gemfiles/common.rb'
+eval_gemfile 'common.rb'
 
 gem 'rails', '~> 5.0.2'
 gem 'actionpack-action_caching'

--- a/gemfiles/rails5.1.gemfile
+++ b/gemfiles/rails5.1.gemfile
@@ -1,4 +1,4 @@
-eval_gemfile 'gemfiles/common.rb'
+eval_gemfile 'common.rb'
 
 gem 'rails', '~> 5.1.0'
 gem 'actionpack-action_caching'


### PR DESCRIPTION
Rails 4.1 isn’t updated no more. People should use Rails 4.2 or higher instead.