### PR TITLE
Update dependencies

### DIFF
--- a/charcoal.gemspec
+++ b/charcoal.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new('charcoal', Charcoal::VERSION) do |s|
   s.add_development_dependency 'rake'
   s.add_development_dependency 'wwtd'
   s.add_development_dependency 'bump'
-  s.add_development_dependency 'yard', '~> 0.7'
+  s.add_development_dependency 'yard', '>= 0.9.11'
 
   s.add_development_dependency 'shoulda', '~> 3.0'
   s.add_development_dependency 'shoulda-context'

--- a/charcoal.gemspec
+++ b/charcoal.gemspec
@@ -20,6 +20,4 @@ Gem::Specification.new('charcoal', Charcoal::VERSION) do |s|
   s.add_development_dependency 'yard', '>= 0.9.11'
 
   s.add_development_dependency 'shoulda', '~> 3.0'
-  s.add_development_dependency 'shoulda-context'
-  s.add_development_dependency 'mocha'
 end

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -8,7 +8,6 @@ rescue LoadError
 end
 
 require 'minitest/autorun'
-require 'mocha/setup'
 
 require 'shoulda'
 require 'active_support/version'


### PR DESCRIPTION
yard < v0.9.11 has a vulnerability. We don’t use `mocha`. `shoulda-context` is already a transient dependency through `shoulda`.
