### PR TITLE
Accept block for credentials configuration, and yield only true or nonexistent state

### DIFF
--- a/lib/charcoal/cross_origin.rb
+++ b/lib/charcoal/cross_origin.rb
@@ -42,13 +42,18 @@ module Charcoal
 
     def set_cors_headers
       headers["Access-Control-Allow-Origin"] = allowed_origin
-      headers["Access-Control-Allow-Credentials"] = Charcoal.configuration["credentials"].to_s
+      headers["Access-Control-Allow-Credentials"] = "true" if credentials_allowed?
       headers["Access-Control-Expose-Headers"] = Charcoal.configuration["expose-headers"].join(",")
     end
 
     def allowed_origin
       value = Charcoal.configuration["allow-origin"]
       value.respond_to?(:call) ? value.call(self) : value.to_s
+    end
+
+    def credentials_allowed?
+      value = Charcoal.configuration["credentials"]
+      value.respond_to?(:call) ? value.call(self) : value
     end
   end
 end


### PR DESCRIPTION
Due to security concerns and in accordance with [documentation](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Allow-Origin#Directives), requests should not respond with both `Access-Control-Allow-Origin: *` and `Access-Control-Allow-Credentials: true`. As such, it would be useful to allow a block/proc/lambda to be passed to the `credentials` configuration -- as is currently the case with `allow-origin` -- so that this header could also be dynamically configured.

Further, [documentation](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Allow-Credentials#Directives) states that `Access-Control-Allow-Credentials` has only one valid value, which is `true`. Otherwise, the header should be omitted. Hence, this change will avoid setting the header altogether if configured with a falsey value.

@zendesk/sustaining @pschambacher @bquorning 