### PR TITLE
update for rails6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,17 +1,23 @@
 cache: bundler
 sudo: false
 rvm:
-  - 2.2
-  - 2.3
   - 2.4
+  - 2.5
+  - 2.6
+  - 2.7
+  - ruby-head
 gemfile:
-  - gemfiles/rails3.2.gemfile
   - gemfiles/rails4.2.gemfile
   - gemfiles/rails5.0.gemfile
   - gemfiles/rails5.1.gemfile
   - gemfiles/rails5.2.gemfile
+  - gemfiles/rails6.0.gemfile
 script: "bundle exec rake test"
 matrix:
   exclude:
     - rvm: 2.4
-      gemfile: gemfiles/rails3.2.gemfile
+      gemfile: gemfiles/rails6.0.gemfile
+    - rvm: 2.7
+      gemfile: gemfiles/rails4.2.gemfile
+  allow_failures:
+    - rvm: ruby-head

--- a/charcoal.gemspec
+++ b/charcoal.gemspec
@@ -7,6 +7,8 @@ Gem::Specification.new('charcoal', Charcoal::VERSION) do |s|
   s.email = "sdavidovitz@zendesk.com"
   s.homepage = "https://github.com/zendesk/charcoal"
 
+  s.required_ruby_version = '>= 2.4.0'
+
   s.files = Dir.glob('{lib,config,app}/**/*')
 
   s.licenses = ['MIT']

--- a/charcoal.gemspec
+++ b/charcoal.gemspec
@@ -11,8 +11,8 @@ Gem::Specification.new('charcoal', Charcoal::VERSION) do |s|
 
   s.licenses = ['MIT']
 
-  s.add_runtime_dependency 'activesupport', '>= 3.2.21', '< 6.0'
-  s.add_runtime_dependency 'actionpack', '>= 3.2.21', '< 6.0'
+  s.add_runtime_dependency 'activesupport', '>= 3.2.21', '< 6.1'
+  s.add_runtime_dependency 'actionpack', '>= 3.2.21', '< 6.1'
 
   s.add_development_dependency 'rake'
   s.add_development_dependency 'wwtd'

--- a/gemfiles/rails3.2.gemfile
+++ b/gemfiles/rails3.2.gemfile
@@ -1,4 +1,0 @@
-eval_gemfile 'common.rb'
-
-gem 'rails', '~> 3.2.21'
-gem 'test-unit-minitest'

--- a/gemfiles/rails6.0.gemfile
+++ b/gemfiles/rails6.0.gemfile
@@ -1,0 +1,4 @@
+eval_gemfile 'common.rb'
+
+gem 'rails', '~> 6.0.0'
+gem 'actionpack-action_caching'

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -50,6 +50,21 @@ class ActiveSupport::TestCase
 end
 
 class ActionController::TestCase
+  if RUBY_VERSION>='2.6.0'
+    if Rails.version < '5'
+      class ActionController::TestResponse < ActionDispatch::TestResponse
+        def recycle!
+          # hack to avoid MonitorMixin double-initialize error:
+          @mon_mutex_owner_object_id = nil
+          @mon_mutex = nil
+          initialize
+        end
+      end
+    else
+      puts "Monkeypatch for ActionController::TestResponse no longer needed"
+    end
+  end
+  
   def setup
     @routes = TestApp.routes
   end


### PR DESCRIPTION
### Description
Update for Rails 6:
- update travis.yml to include support for latest ruby and rails versions
- remove support for ruby < 2.4 and rails < 4.2
- add gemfiles for rails 6
- add test patch for Rails 4.2 and Ruby 2.6

### References
https://zendesk.atlassian.net/browse/WALR-2073
https://github.com/rails/rails/issues/34790

### Risks
**Low**