### PR TITLE
Update Charcoal::CrossOriginController to use ActionController::Metal

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,3 @@
 source 'https://rubygems.org'
 
-gemspec
-
-gem "rails", "~> 4.2.5"
+eval_gemfile('gemfiles/rails4.2.gemfile')

--- a/lib/charcoal/cross_origin_controller.rb
+++ b/lib/charcoal/cross_origin_controller.rb
@@ -1,11 +1,14 @@
 # This controller handles CORS preflight requests
 # See https://developer.mozilla.org/En/HTTP_access_control for documentation
 
-require 'action_controller'
+require 'action_controller/metal'
 require 'active_support/version'
 require 'charcoal/utilities'
 
-class Charcoal::CrossOriginController < ActionController::Base
+class Charcoal::CrossOriginController < ActionController::Metal
+  include AbstractController::Callbacks
+  include ActionController::Head
+  include ActionController::Instrumentation
   include Charcoal::CrossOrigin
   include Charcoal::Utilities
 


### PR DESCRIPTION
Rails 5.2 moved forgery protection to ActionController::Base (rails/rails@ec4a836) - which can lead to any OPTIONS request that is routed to `Charcoal::CrossOriginController` to raise an `ActionController::InvalidAuthenticityToken` for application that migrate to the new Rails defaults (since [only GET requests are excluded from CSRF checks](https://api.rubyonrails.org/classes/ActionController/RequestForgeryProtection.html)).

This updates the `Charcoal::CrossOriginController` to instead use `ActionController::Metal` (and a few required modules), which resolves the issue of CSRF checks inadvertently raising errors from this controller - and [removes a good amount of overhead](https://github.com/rails/rails/blob/2a3f8a29e5d7d17a0448fa47fd756c8d11b175b1/actionpack/lib/action_controller/base.rb#L205-L250).

Sidenote, 3972d48 was needed to get tests working for me in development.