### PR TITLE
Enable compatibility with Rails 6.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,7 @@ jobs:
           - rails5.1
           - rails5.2
           - rails6.0
+          - rails6.1
         exclude:
           - ruby-version: '2.5'
             gemfile: rails4.2

--- a/charcoal.gemspec
+++ b/charcoal.gemspec
@@ -15,8 +15,8 @@ Gem::Specification.new('charcoal', Charcoal::VERSION) do |s|
 
   s.required_ruby_version = '>= 2.5'
 
-  s.add_runtime_dependency 'activesupport', '>= 3.2.21', '< 6.1'
-  s.add_runtime_dependency 'actionpack', '>= 3.2.21', '< 6.1'
+  s.add_runtime_dependency 'activesupport', '>= 3.2.21', '< 6.2'
+  s.add_runtime_dependency 'actionpack', '>= 3.2.21', '< 6.2'
 
   s.add_development_dependency 'rake'
   s.add_development_dependency 'bump'

--- a/gemfiles/rails6.1.gemfile
+++ b/gemfiles/rails6.1.gemfile
@@ -1,0 +1,4 @@
+eval_gemfile 'common.rb'
+
+gem 'rails', '~> 6.1.0'
+gem 'actionpack-action_caching', github: 'rails/actionpack-action_caching', ref: '7bdfa663274a2620dde8daad7dcb995c1cfef840'

--- a/test/jsonp_test.rb
+++ b/test/jsonp_test.rb
@@ -40,7 +40,7 @@ class JSONPTest < ActionController::TestCase
         end
 
         should "return a proper response type" do
-          assert_equal "application/javascript", @response.content_type
+          assert_equal "application/javascript", media_type(@response)
         end
 
         context "a second call" do
@@ -57,7 +57,7 @@ class JSONPTest < ActionController::TestCase
           end
 
           should "properly cache the response type" do
-            assert_equal "application/javascript", @response.content_type
+            assert_equal "application/javascript", media_type(@response)
           end
         end
       end
@@ -93,7 +93,7 @@ class JSONPTest < ActionController::TestCase
         end
 
         should "change content-type" do
-          assert_equal "application/javascript", subject.response.content_type
+          assert_equal "application/javascript", media_type(subject.response)
         end
       end
 
@@ -105,9 +105,17 @@ class JSONPTest < ActionController::TestCase
         end
 
         should "not change content-type" do
-          assert_equal @content_type, subject.response.content_type
+          assert_equal @content_type, media_type(subject.response)
         end
       end
+    end
+  end
+
+  def media_type(response)
+    if ActiveSupport::VERSION::MAJOR < 5
+      response.content_type
+    else
+      response.media_type
     end
   end
 end


### PR DESCRIPTION
~Blocked by #27.~
~Blocked by #28.~

When running the tests with Rails 6.0, you would see this deprecation warning:

    DEPRECATION WARNING: Rails 6.1 will return Content-Type header without modification. If you want just the MIME type, please use `#media_type` instead.

For this reason, I have added a `#media_type` helper method at the end of the jsonp_test.rb file to easily work across Rails versions.