### PR TITLE
Drop support for Ruby 2.4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,6 @@ jobs:
       fail-fast: false
       matrix:
         ruby-version:
-          - '2.4'
           - '2.5'
           - '2.6'
           - '2.7'
@@ -22,8 +21,6 @@ jobs:
           - rails5.2
           - rails6.0
         exclude:
-          - ruby-version: '2.4'
-            gemfile: rails6.0
           - ruby-version: '2.5'
             gemfile: rails4.2
           - ruby-version: '2.6'
@@ -46,13 +43,6 @@ jobs:
         uses: zendesk/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby-version }}
-          bundler: 1
-        if: ${{ matrix.ruby-version == '2.4' }}
-      - name: Set up Ruby
-        uses: zendesk/setup-ruby@v1
-        with:
-          ruby-version: ${{ matrix.ruby-version }}
-        if: ${{ matrix.ruby-version != '2.4' }}
       - run: bundle install
       - name: Tests
         run: bundle exec rake test

--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ This example adds the `allow_animals` directive that logs "QUACK!" if an applica
 
 ## Supported Versions
 
-Ruby >= 2.4 and Rails >= 4.2.
+Ruby >= 2.5 and Rails >= 4.2.
 
 [![Build Status](https://github.com/zendesk/charcoal/workflows/CI/badge.svg)](https://github.com/zendesk/charcoal/actions?query=workflow%3ACI)
 

--- a/charcoal.gemspec
+++ b/charcoal.gemspec
@@ -13,6 +13,8 @@ Gem::Specification.new('charcoal', Charcoal::VERSION) do |s|
 
   s.licenses = ['MIT']
 
+  s.required_ruby_version = '>= 2.5'
+
   s.add_runtime_dependency 'activesupport', '>= 3.2.21', '< 6.1'
   s.add_runtime_dependency 'actionpack', '>= 3.2.21', '< 6.1'
 

--- a/gemfiles/rails4.2.gemfile
+++ b/gemfiles/rails4.2.gemfile
@@ -2,4 +2,3 @@ eval_gemfile 'common.rb'
 
 gem 'rails', '~> 4.2.5'
 gem 'actionpack-action_caching'
-gem 'nokogiri', '< 1.7' if RUBY_VERSION < '2.1.0'


### PR DESCRIPTION
Support of Ruby 2.4 has ended several months ago: https://www.ruby-lang.org/en/news/2020/04/05/support-of-ruby-2-4-has-ended/