### PR TITLE
add tests with Rails 7.2 and 8.0, handle deprecations in tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,20 +10,26 @@ jobs:
       fail-fast: false
       matrix:
         ruby-version:
-          - '3.1'
           - '3.2'
           - '3.3'
         gemfile:
           - rails6.1
           - rails7.0
           - rails7.1
+          - rails7.2
+          - rails8.0
           - rails_main
+        include:
+          - {ruby-version: '3.1', gemfile: rails6.1}
+          - {ruby-version: '3.1', gemfile: rails7.0}
+          - {ruby-version: '3.1', gemfile: rails7.1}
+          - {ruby-version: '3.1', gemfile: rails7.2}
     env:
       BUNDLE_GEMFILE: gemfiles/${{ matrix.gemfile }}.gemfile
     steps:
-      - uses: zendesk/checkout@v4
+      - uses: actions/checkout@v4
       - name: Set up Ruby
-        uses: zendesk/setup-ruby@v1
+        uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby-version }}
       - run: bundle install

--- a/README.md
+++ b/README.md
@@ -28,7 +28,6 @@ Include the module `Charcoal::CrossOrigin` in the controller you'd like to allow
 
 Included is a CORS pre-flight controller that must be hooked up to the Rails router:
 
-Rails 5:
 ```ruby
 match '*path', :to => 'charcoal/cross_origin#preflight', :via => :options
 ```
@@ -101,9 +100,9 @@ This example adds the `allow_animals` directive that logs "QUACK!" if an applica
 
 ## Supported Versions
 
-Ruby >= 2.7 and Rails >= 5.2.
+Ruby >= 3.1 and Rails >= 6.1
 
-[![Build Status](https://github.com/zendesk/charcoal/workflows/CI/badge.svg)](https://github.com/zendesk/charcoal/actions?query=workflow%3ACI)
+[![CI status](https://github.com/zendesk/charcoal/actions/workflows/ci.yml/badge.svg)](https://github.com/zendesk/charcoal/actions/workflows/ci.yml)
 
 ## Contributing to charcoal
 

--- a/gemfiles/rails7.2.gemfile
+++ b/gemfiles/rails7.2.gemfile
@@ -1,0 +1,4 @@
+eval_gemfile "common.rb"
+
+gem "rails", "~> 7.2.0"
+gem "actionpack-action_caching"

--- a/gemfiles/rails8.0.gemfile
+++ b/gemfiles/rails8.0.gemfile
@@ -1,0 +1,4 @@
+eval_gemfile "common.rb"
+
+gem "rails", "~> 8.0.0"
+gem "actionpack-action_caching"

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -17,6 +17,7 @@ require "rails/test_unit/railtie"
 
 class TestApp < Rails::Application
   config.active_support.deprecation = :stderr
+  config.active_support.to_time_preserves_timezone = :zone
   config.active_support.test_order = :random if config.active_support.respond_to?(:test_order=)
   config.eager_load = false
   config.secret_key_base = "secret"
@@ -36,7 +37,12 @@ TestApp.routes.draw do
   mount TestEngine => ""
   match "/test" => "test#test", :via => [:get, :put]
   match "*path.:format" => "charcoal/cross_origin#preflight", :via => :options
-  get ":controller/:action"
+  get "test_controller/test_action", to: "test_controller#test_action"
+  get "test_cors/test_action", to: "test_cors#test_action"
+  get "test_cors/test", to: "test_cors#test"
+  get "test_cors/test_error_action", to: "test_cors#test_error_action"
+  get "jsonp_controller_tester/test", to: "jsonp_controller_tester#test"
+  get "charcoal/cross_origin/preflight", to: "charcoal/cross_origin#preflight"
 end
 
 class ActiveSupport::TestCase


### PR DESCRIPTION
Notes on deprecations:
1. Dynamic `:controller` and `:action` segments have been deprecated. We replace them with a static list of routes that we use in tests.
2. “`to_time` will always preserve the receiver timezone rather than system local time in Rails 8.1”. We don’t really care one way or another in this test app, so we opt in for the new behaviour.