### PR TITLE
Remove actionpack-action_caching from test setup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,9 +32,24 @@ jobs:
         uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby-version }}
-      - run: bundle install
+          bundler-cache: true
       - name: Tests
         run: bundle exec rake test
+
+  tests_successful:
+    name: Tests passing?
+    needs: tests
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - run: |
+          if ${{ needs.tests.result == 'success' }}
+          then
+            echo "All tests pass"
+          else
+            echo "Some tests failed"
+            false
+          fi
 
   linter:
     runs-on: ubuntu-latest

--- a/charcoal.gemspec
+++ b/charcoal.gemspec
@@ -13,11 +13,6 @@ Gem::Specification.new("charcoal", Charcoal::VERSION) do |s|
 
   s.licenses = ["MIT"]
 
-  s.add_runtime_dependency "activesupport", ">= 6.1"
-  s.add_runtime_dependency "actionpack", ">= 6.1"
-
-  s.add_development_dependency "rake"
-  s.add_development_dependency "yard", ">= 0.9.11"
-
-  s.add_development_dependency "shoulda", "~> 3.0"
+  s.add_dependency "activesupport", ">= 6.1"
+  s.add_dependency "actionpack", ">= 6.1"
 end

--- a/gemfiles/common.rb
+++ b/gemfiles/common.rb
@@ -3,4 +3,7 @@ source "https://rubygems.org"
 gemspec path: "../"
 
 gem "byebug", platforms: :mri
+gem "rake"
+gem "shoulda", "~> 3.0"
 gem "standard"
+gem "yard", ">= 0.9.11"

--- a/gemfiles/rails6.1.gemfile
+++ b/gemfiles/rails6.1.gemfile
@@ -1,4 +1,3 @@
 eval_gemfile "common.rb"
 
 gem "rails", "~> 6.1.0"
-gem "actionpack-action_caching"

--- a/gemfiles/rails7.0.gemfile
+++ b/gemfiles/rails7.0.gemfile
@@ -1,4 +1,3 @@
 eval_gemfile "common.rb"
 
 gem "rails", "~> 7.0.0"
-gem "actionpack-action_caching"

--- a/gemfiles/rails7.1.gemfile
+++ b/gemfiles/rails7.1.gemfile
@@ -1,4 +1,3 @@
 eval_gemfile "common.rb"
 
 gem "rails", "~> 7.1.0"
-gem "actionpack-action_caching"

--- a/gemfiles/rails7.2.gemfile
+++ b/gemfiles/rails7.2.gemfile
@@ -1,4 +1,3 @@
 eval_gemfile "common.rb"
 
 gem "rails", "~> 7.2.0"
-gem "actionpack-action_caching"

--- a/gemfiles/rails8.0.gemfile
+++ b/gemfiles/rails8.0.gemfile
@@ -1,4 +1,3 @@
 eval_gemfile "common.rb"
 
 gem "rails", "~> 8.0.0"
-gem "actionpack-action_caching"

--- a/gemfiles/rails_main.gemfile
+++ b/gemfiles/rails_main.gemfile
@@ -1,4 +1,3 @@
 eval_gemfile "common.rb"
 
 gem "rails", github: "rails/rails", branch: "main"
-gem "actionpack-action_caching"

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -57,5 +57,4 @@ class ActionController::TestCase
   end
 end
 
-require "action_controller/action_caching"
 require "charcoal"

--- a/test/jsonp_test.rb
+++ b/test/jsonp_test.rb
@@ -3,7 +3,6 @@ require File.expand_path("helper", File.dirname(__FILE__))
 class JSONPControllerTester < ActionController::Base
   include Charcoal::JSONP
 
-  caches_action :test
   allow_jsonp :test
 
   def test


### PR DESCRIPTION
The `caches_action` call was added in one of the first commits, when we were testing against Rails 2.3 – long before actionpack-action_caching was removed from Rails and published as a separate gem. A gem which has not been updated for three years and which is compatible with Rails 6.1 and older.