### PR TITLE
Define HTTP_METHODS locally instead of relying on Rails internals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [2.9.0] - 2026-07-24
 
+* Fixed compatibility with Rails main after `ActionDispatch::Routing::HTTP_METHODS` was removed.
 * Dropped support for Ruby 3.1
 * Dropped support for Rails 6.1
 

--- a/gemfiles/rails7.0.gemfile.lock
+++ b/gemfiles/rails7.0.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    charcoal (2.8.0)
+    charcoal (2.9.0)
       actionpack (>= 7.0)
       activesupport (>= 7.0)
 

--- a/gemfiles/rails7.1.gemfile.lock
+++ b/gemfiles/rails7.1.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    charcoal (2.8.0)
+    charcoal (2.9.0)
       actionpack (>= 7.0)
       activesupport (>= 7.0)
 

--- a/gemfiles/rails7.2.gemfile.lock
+++ b/gemfiles/rails7.2.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    charcoal (2.8.0)
+    charcoal (2.9.0)
       actionpack (>= 7.0)
       activesupport (>= 7.0)
 

--- a/gemfiles/rails8.0.gemfile.lock
+++ b/gemfiles/rails8.0.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    charcoal (2.8.0)
+    charcoal (2.9.0)
       actionpack (>= 7.0)
       activesupport (>= 7.0)
 

--- a/lib/charcoal/utilities.rb
+++ b/lib/charcoal/utilities.rb
@@ -1,7 +1,27 @@
 require "action_controller"
+require "action_dispatch"
 
 module Charcoal::Utilities
-  Routing = defined?(ActionDispatch) ? ActionDispatch::Routing : ActionController::Routing
+  # OPTIONS is the preflight question, not an answer. CONNECT/TRACE/TRACK are
+  # "forbidden methods" the browser won't send cross-origin.
+  # See https://fetch.spec.whatwg.org/#forbidden-method
+  FORBIDDEN_CORS_METHODS = %w[OPTIONS CONNECT TRACE TRACK].freeze
+
+  # WebDAV / versioning families (PROPFIND, MKCOL, REPORT, …): recognized by
+  # Rails but never sent cross-origin. These are the RFC groups ActionDispatch
+  # concatenates to build HTTP_METHODS.
+  WEBDAV_METHODS = [
+    *ActionDispatch::Request::RFC2518,
+    *ActionDispatch::Request::RFC3253,
+    *ActionDispatch::Request::RFC3648,
+    *ActionDispatch::Request::RFC3744,
+    *ActionDispatch::Request::RFC5323,
+    *ActionDispatch::Request::RFC4791
+  ].freeze
+
+  # Verbs advertised in Access-Control-Allow-Methods.
+  HTTP_METHODS = (ActionDispatch::Request::HTTP_METHODS - FORBIDDEN_CORS_METHODS - WEBDAV_METHODS)
+    .map { |v| v.downcase.to_sym }.freeze
 
   def allowed_methods_for?(protocol)
     @allowed_methods ||= {}
@@ -12,9 +32,7 @@ module Charcoal::Utilities
   private
 
   def methods_allowed_for?(protocol)
-    Routing::HTTP_METHODS.select do |verb|
-      next if verb == :options
-
+    HTTP_METHODS.select do |verb|
       route = find_route(request.path, request.env.merge(method: verb))
 
       if route

--- a/lib/charcoal/version.rb
+++ b/lib/charcoal/version.rb
@@ -1,3 +1,3 @@
 module Charcoal
-  VERSION = "2.8.0"
+  VERSION = "2.9.0"
 end

--- a/test/cross_origin_controller_test.rb
+++ b/test/cross_origin_controller_test.rb
@@ -20,6 +20,16 @@ class EngineController < ActionController::Base
   end
 end
 
+class CatchAllController < ActionController::Base
+  include Charcoal::CrossOrigin
+
+  allow_cors :any
+
+  # mounted at "/catch_all" with `via: :all`
+  def any
+  end
+end
+
 class Charcoal::CrossOriginControllerTest < ActionController::TestCase
   context Charcoal::CrossOriginController do
     setup do
@@ -65,6 +75,18 @@ class Charcoal::CrossOriginControllerTest < ActionController::TestCase
           assert @response.body.blank?
           assert_match %r{text/plain}, @response.headers["Content-Type"], @response.headers.inspect
         end
+      end
+    end
+
+    context "route matching every verb (via: :all)" do
+      setup do
+        @request.path = "/catch_all"
+        get :preflight
+      end
+
+      should "advertise every CORS verb Charcoal supports" do
+        allowed = Charcoal::Utilities::HTTP_METHODS.map { |verb| verb.to_s.upcase }
+        assert_equal allowed.join(","), @response.headers["Access-Control-Allow-Methods"], @response.headers.inspect
       end
     end
 

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -36,6 +36,7 @@ end
 TestApp.routes.draw do
   mount TestEngine => ""
   match "/test" => "test#test", :via => [:get, :put]
+  match "/catch_all" => "catch_all#any", :via => :all
   match "*path.:format" => "charcoal/cross_origin#preflight", :via => :options
   get "test_controller/test_action", to: "test_controller#test_action"
   get "test_cors/test_action", to: "test_cors#test_action"

--- a/test/utilities_test.rb
+++ b/test/utilities_test.rb
@@ -35,3 +35,17 @@ class TestCorsControllerTest < ActionController::TestCase
     end
   end
 end
+
+class UtilitiesHttpMethodsTest < ActiveSupport::TestCase
+  context "Charcoal::Utilities::HTTP_METHODS" do
+    setup do
+      @expected_verbs = [:get, :head, :post, :put, :delete, :patch]
+      # When Rails adds QUERY support https://github.com/rails/rails/pull/57973
+      @expected_verbs << :query if ActionDispatch::Request.const_defined?(:RFC10008)
+    end
+
+    should "contain exactly the advertised CORS verbs" do
+      assert_equal @expected_verbs, Charcoal::Utilities::HTTP_METHODS
+    end
+  end
+end


### PR DESCRIPTION
Rails removed the internal `ActionDispatch::Routing::HTTP_METHODS` constant (rails/rails@cd558d7). Charcoal used it to build the CORS `Access-Control-Allow-Methods` header, so define our own list of verbs instead. `OPTIONS` is dropped from the list rather than skipped in code.